### PR TITLE
feat: don't use eslint-config-typescript legacy preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,6 @@ Turo eslint configuration for react. The config expects that Typescript is being
 [![Conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.2-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Join us!](https://img.shields.io/badge/Turo-Join%20us%21-593CFB.svg)](https://turo.com/jobs)
 
-## Relevant notes
-
-The `eslint` configurations in this repo extend `@open-turo/eslint-config-typescript/legacy`; as it is the base TS
-eslint config that supports our existing front-end codebase.
-
-However, if you are creating a new React project and you think you would benefit from having the configurations in this
-repository extend the default `@open-turo/eslint-config-typescript` config instead, please raise an issue and/or feel
-free to create a PR to add a new default that extends it, and rename the current configurations to `legacy` and
-`legacy-extended` respectively. We are not doing that for now to reduce maintenance burden, as it would be unused.
-
 ## Usage
 
 Install the package and all of its peer dependencies:
@@ -39,8 +29,18 @@ To use this config, just add to your `.eslintrc` the following:
 "extends": "@open-turo/eslint-config-typescript"
 ```
 
-We used to have an alternative `extended` preset, which added more react-related plugins, but after some testing, it
-has been integrated into the default preset.
+### Legacy preset
+
+There is a `legacy` preset that extends `@open-turo/eslint-config-typescript/legacy`. This only exists for backwards
+compatibility with existing projects. It is strongly recommended to use the standard preset.
+
+To use the `legacy` preset, update your `.eslintrc` file to be:
+
+```json
+{
+  "extends": "@open-turo/eslint-config-react/legacy"
+}
+```
 
 ## Development
 

--- a/docs/breaking-changes/v7.md
+++ b/docs/breaking-changes/v7.md
@@ -1,0 +1,15 @@
+# Breaking changes in v6
+
+This preset now uses the standard config from `@open-turo/eslint-config-typescript`. There is now a `legacy` preset that
+extends `@open-turo/eslint-config-typescript/legacy`.
+
+## Upgrade instructions
+
+It is strongly recommended to use the standard preset. If you want to still use the previous configuration,
+you can switch to the `legacy` preset by updating your `.eslintrc` file to be:
+
+```json
+{
+  "extends": "@open-turo/eslint-config-react/legacy"
+}
+```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
   extends: [
     "@open-turo/eslint-config-typescript",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
   ],
@@ -43,6 +44,8 @@ module.exports = {
     "react/jsx-props-no-spreading": "off",
     // ensure props are alphabetical
     "react/jsx-sort-props": "error",
+    // Allow emotion css prop
+    "react/no-unknown-property": ["error", { ignore: ["css"] }],
     // We don't need default props on TS components
     "react/require-default-props": "off",
     "react/sort-prop-types": "error",
@@ -50,6 +53,8 @@ module.exports = {
     "react/state-in-constructor": "off",
     // This allows static properties to be placed within the class declaration
     "react/static-property-placement": "off",
+    // Allow file names to match a component name
+    "unicorn/filename-case": "off",
   },
   settings: {
     react: {

--- a/legacy.js
+++ b/legacy.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   ignorePatterns: ["babel.config.js"],
   extends: [
-    "@open-turo/eslint-config-typescript",
+    "@open-turo/eslint-config-typescript/legacy",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",


### PR DESCRIPTION

**Description**

While reviewing the eslint overrides of one of our internal libs, I realized that this plugin was referencing the legacy preset of `eslint-config-typescript` and I also saw some overrides that we could probably make part of this repo.

There are 2 overrides: 

* Allow the css prop in components for libs that use `emotion`
* Add the jsx-runtime eslint plugin
* Allow camelcase for file names so that files can be named after a component name

**Changes**

* feat: don't use eslint-config-typescript legacy preset
* feat: add new rules to match our latest conventions

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
