### PR TITLE
feat: upgrade @open-turo/eslint-config-react to v14

### DIFF
--- a/docs/breaking-changes/v14.md
+++ b/docs/breaking-changes/v14.md
@@ -1,0 +1,3 @@
+# Breaking changes in v14
+
+We now enforce `plugin:@typescript-eslint/strict-type-checked` in `@open-turo/eslint-config-typescript` (with some exceptions), which will raise new errors in usage.


### PR DESCRIPTION
BREAKING CHANGE: 13.0.10 was accidentally cut as a patch. v14 includes new type errors from plugin:@typescript-eslint/strict-type-checked that will need to be resolved

https://github.com/open-turo/eslint-config-react/pull/312