### PR TITLE
fix: build config to include typed options instead of object typing

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 const turoConfig = require("@open-turo/eslint-config-typescript");
 const jsxA11yPlugin = require("eslint-plugin-jsx-a11y");
 const reactPlugin = require("eslint-plugin-react");
@@ -7,9 +9,8 @@ const globals = require("globals");
 const tseslint = require("typescript-eslint");
 
 /**
- *
  * @param {object} options ESLint configuration options
- * @param {object} options.turo ESLing configuration options for open-turo/eslint-config-typescript. See their documentation for available options.
+ * @param {Parameters<typeof turoConfig>[0]} [options.turo] ESLint configuration options for `@open-turo/eslint-config-typescript`
  * @returns Configuration Array
  */
 module.exports = function config(options = {}) {
@@ -70,7 +71,7 @@ module.exports = function config(options = {}) {
     },
     {
       extends: [
-        reactPlugin.configs.flat.recommended,
+        reactPlugin.configs.flat["recommended"],
         reactPlugin.configs.flat["jsx-runtime"],
         jsxA11yPlugin.flatConfigs.recommended,
         reactCompilerPlugin.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.0.3",
       "license": "MIT",
       "dependencies": {
-        "@open-turo/eslint-config-typescript": "16.0.7",
+        "@open-turo/eslint-config-typescript": "16.0.8",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-compiler": "19.0.0-beta-ebf51a3-20250411",
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/@open-turo/eslint-config-typescript": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@open-turo/eslint-config-typescript/-/eslint-config-typescript-16.0.7.tgz",
-      "integrity": "sha512-St1jJAvNRrjC50w7/HxZlFCMkPYOS1VI3CBmberwAKVtfMDRsdEa2S5yPbcFmcoHs1c9r61qvkiCqeMWfmn0SQ==",
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/@open-turo/eslint-config-typescript/-/eslint-config-typescript-16.0.8.tgz",
+      "integrity": "sha512-674AvvqSu4L9Iuk8FXrQ2uOuz4T5I5C3kOZqgErBCIhzAxT402unGc6AMWpDlniu15CCsxTR48OFWEXs5V+1Mg==",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "9.29.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Turo eslint configuration for react",
   "type": "module",
   "dependencies": {
-    "@open-turo/eslint-config-typescript": "16.0.7",
+    "@open-turo/eslint-config-typescript": "16.0.8",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-compiler": "19.0.0-beta-ebf51a3-20250411",


### PR DESCRIPTION
`eslint-config-react` complement of https://github.com/open-turo/eslint-config-typescript/pull/395.

![Screenshot 2025-06-17 at 4 40 09 PM](https://github.com/user-attachments/assets/fede24c4-bd8a-4b52-81ba-ab9c58a20326)
![Screenshot 2025-06-17 at 4 40 04 PM](https://github.com/user-attachments/assets/fba46db9-29c1-4293-8549-bdb4de666aaa)

After:

![Screenshot 2025-06-17 at 5 06 48 PM](https://github.com/user-attachments/assets/c37086ee-082b-4a16-a29c-171729b1c35b)
